### PR TITLE
Add machine state to machine allocation info.

### DIFF
--- a/metalCollector.go
+++ b/metalCollector.go
@@ -319,8 +319,12 @@ func (collector *metalCollector) Collect(ch chan<- prometheus.Metric) {
 			hostname    = "NOTALLOCATED"
 			clusterID   = "NOTALLOCATED"
 			primaryASN  = "NOTALLOCATED"
-			state       = pointer.SafeDeref(pointer.SafeDeref(m.State).Value)
+			state       = "AVAILABLE"
 		)
+
+		if m.State != nil && m.State.Value != nil && *m.State.Value != "" {
+			state = *m.State.Value
+		}
 
 		if m.Allocation != nil {
 			if m.Allocation.Role != nil {

--- a/metalCollector.go
+++ b/metalCollector.go
@@ -128,7 +128,7 @@ func newMetalCollector(client metalgo.Client) *metalCollector {
 		machineAllocationInfo: prometheus.NewDesc(
 			"metal_machine_allocation_info",
 			"Provide information about the machine allocation",
-			[]string{"machineid", "partition", "machinename", "clusterTag", "primaryASN", "role"}, nil,
+			[]string{"machineid", "partition", "machinename", "clusterTag", "primaryASN", "role", "state"}, nil,
 		),
 		machineIssuesInfo: prometheus.NewDesc(
 			"metal_machine_issues_info",
@@ -319,6 +319,7 @@ func (collector *metalCollector) Collect(ch chan<- prometheus.Metric) {
 			hostname    = "NOTALLOCATED"
 			clusterID   = "NOTALLOCATED"
 			primaryASN  = "NOTALLOCATED"
+			state       = pointer.SafeDeref(pointer.SafeDeref(m.State).Value)
 		)
 
 		if m.Allocation != nil {
@@ -342,7 +343,7 @@ func (collector *metalCollector) Collect(ch chan<- prometheus.Metric) {
 			partitionID = *m.Partition.ID
 		}
 
-		ch <- prometheus.MustNewConstMetric(collector.machineAllocationInfo, prometheus.GaugeValue, 1.0, *m.ID, partitionID, hostname, clusterID, primaryASN, role)
+		ch <- prometheus.MustNewConstMetric(collector.machineAllocationInfo, prometheus.GaugeValue, 1.0, *m.ID, partitionID, hostname, clusterID, primaryASN, role, state)
 
 		for issueID := range allIssuesByID {
 			machineIssues, ok := issuesByMachineID[*m.ID]


### PR DESCRIPTION
This information is interesting as it marks a machine that is locked for being investigated by an operator. This way, an operator can silence alerts by locking a machine.